### PR TITLE
feat: include response headers in trpc context

### DIFF
--- a/app/api/context.ts
+++ b/app/api/context.ts
@@ -1,11 +1,15 @@
-import type { FetchCreateContextFnOptions } from "@trpc/server/adapters/fetch";
-
-export function createContext(fetchCtx: FetchCreateContextFnOptions) {
+export function createContext({
+  req,
+  resHeaders,
+}: {
+  req: Request;
+  resHeaders: Headers;
+}) {
   // As an example, you can retrieve auth or other information here.
   // const user = { name: fetchCtx.req.headers.get("username") ?? "anonymous" };
-
   return {
-    ...fetchCtx,
+    req,
+    resHeaders,
     // user,
   };
 }

--- a/app/api/context.ts
+++ b/app/api/context.ts
@@ -6,7 +6,7 @@ export function createContext({
   resHeaders: Headers;
 }) {
   // As an example, you can retrieve auth or other information here.
-  // const user = { name: fetchCtx.req.headers.get("username") ?? "anonymous" };
+  // const user = { name: req.headers.get("username") ?? "anonymous" };
   return {
     req,
     resHeaders,

--- a/app/api/context.ts
+++ b/app/api/context.ts
@@ -1,9 +1,11 @@
-export function createContext({ req }: { req: Request }) {
+import type { FetchCreateContextFnOptions } from "@trpc/server/adapters/fetch";
+
+export function createContext(fetchCtx: FetchCreateContextFnOptions) {
   // As an example, you can retrieve auth or other information here.
-  // const user = { name: req.headers.get("username") ?? "anonymous" };
+  // const user = { name: fetchCtx.req.headers.get("username") ?? "anonymous" };
 
   return {
-    req,
+    ...fetchCtx,
     // user,
   };
 }

--- a/app/lib/prefetch.ts
+++ b/app/lib/prefetch.ts
@@ -24,20 +24,27 @@ export const queryClientMiddleware: Route.unstable_MiddlewareFunction = async ({
 export const trpcContext =
   unstable_createContext<TRPCOptionsProxy<AppRouter>>();
 
-export const trpcMiddleware: Route.unstable_MiddlewareFunction = ({
-  request,
-  context,
-}) => {
+export const trpcMiddleware: Route.unstable_MiddlewareFunction = async (
+  { request, context },
+  next,
+) => {
   const queryClient = context.get(queryClientContext);
+  const resHeaders = new Headers();
 
   context.set(
     trpcContext,
     createTRPCOptionsProxy({
-      ctx: createContext({ req: request }),
+      ctx: createContext({ req: request, resHeaders }),
       router: appRouter,
       queryClient,
     }),
   );
+
+  const res = await next();
+
+  resHeaders.forEach((v, k) => res.headers.append(k, v));
+
+  return res;
 };
 
 /**


### PR DESCRIPTION
`FetchCreateContextFnOptions` has the request (as `req` still), response headers (`resHeaders`), and what looks to be trpc specific info about the request (`info`). I think it would be good to add this because it trivializes setting cookies via a trpc procedure.